### PR TITLE
Create card components in grid

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -14,7 +14,7 @@
 }
 
 .App-header {
-  background-color: #282c34;
+  background-color: #F6F8FC;
   min-height: 100vh;
   display: flex;
   flex-direction: column;
@@ -51,19 +51,52 @@
 }
 
 .card {
-  width: 230px;
-  height: 350px;
-  background-color: gray;
+  width: 319px;
+  height: 192px;
+  background-color: #FFFFFF;
+  box-shadow: 0px 5px 20px 1px rgba(0, 0, 0, 0.1);
   padding: 8px;
-  border-radius: 16px;
+  border-radius: 20px;
   font-size: 24px;
 }
 
 .card img {
   /* object-fit: cover; */
-  width: 70%;
+  width: 50%;
   /* height: 70%; */
   margin: auto;
+  position: relative;
+  top: -40%;
+}
+
+.id {
+  position: relative;
+  top: -45%;
+  margin-bottom: 0px;
+  color: #8F9396;
+  font-weight: bold;
+  font-size: 16px;
+}
+
+.name {
+  position: relative;
+  top: -45%;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  color: #000000;
+  font-weight: bold;
+}
+
+.type {
+  margin: auto;
+  position: relative;
+  top: -45%;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  /* width: 60px; */
+  padding: 2px;
+  color: #000000;
+  font-size: 16px;
 }
 
 .container {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,7 +42,7 @@ function App() {
       <Pokemon />
       {/* <Pokemon id={2} name={'b'} type={'fire'} image={'img'}/> */}
         {/* <img src={logo} className="App-logo" alt="logo" /> */}
-        <p>
+        {/* <p>
           Edit <code>src/App.tsx</code> and save to reload.
         </p>
         <a
@@ -52,7 +52,7 @@ function App() {
           rel="noopener noreferrer"
         >
           Learn React
-        </a>
+        </a> */}
       </header>
     </div>
   );

--- a/src/PokeCard/PokeCard.tsx
+++ b/src/PokeCard/PokeCard.tsx
@@ -1,0 +1,21 @@
+import React, {useState} from 'react';
+
+interface IPokemon {
+    id: number;
+    name: string;
+    image: string;
+    type: string;
+}
+
+export const PokeCard = ({id, name, image, type}:IPokemon) => {
+    return (
+        <div>
+            <div className="card">
+            <img src={image} />
+            <p className="id">#{id}</p>
+            <p className="name">{name}</p>
+            <p className='type'> {type} </p>
+            </div>
+        </div>
+    )
+}

--- a/src/PokeCard/index.ts
+++ b/src/PokeCard/index.ts
@@ -1,0 +1,1 @@
+export {PokeCard} from './PokeCard'

--- a/src/Pokemon.tsx
+++ b/src/Pokemon.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { isPlusToken } from 'typescript';
+import { PokeCard } from './PokeCard';
 
 interface IPokemon {
     id: number;
@@ -10,10 +10,10 @@ interface IPokemon {
 
 // function Pokemon({id, name, image, type}:IPokemon) {
 function Pokemon() {
-    const [name, setName] = useState('' || []);
+    const [name, setName] = useState<any>('' || []);
     const [type, setType] = useState('');
     const [image, setImage] = useState('');
-    const [id, setId] = useState('');
+    const [id, setId] = useState(0);
 
     useEffect(() => {
         getPokemon(1)
@@ -29,6 +29,7 @@ function Pokemon() {
             .map((poke: any) => poke.ability.name)
             .join(", ")
         console.log(pokemonAbilities)
+
         const transformedPokemon = {
             id: pokemon.id,
             name: pokemon.name,
@@ -54,41 +55,7 @@ function Pokemon() {
     const typeColour = "white";
     return (
         <div className="cards">
-            <div className="card">
-            <img src={image} />
-            <p className="title">{id} - {name}</p>
-            <p style={{ color: typeColour }}> {type} </p>
-            </div>
-
-            <div className="card">
-            <img src={image} />
-            <p className="title">{id} - {name}</p>
-            <p> {type} </p>
-            </div>
-
-            <div className="card">
-            <img src={image} />
-            <p className="title">{id} - {name}</p>
-            <p> {type} </p>
-            </div>
-
-            <div className="card">
-            <img src={image} />
-            <p className="title">{id} - {name}</p>
-            <p> {type} </p>
-            </div>
-
-            <div className="card">
-            <img src={image} />
-            <p className="title">{id} - {name}</p>
-            <p> {type} </p>
-            </div>
-
-            <div className="card">
-            <img src={image} />
-            <p className="title">{id} - {name}</p>
-            <p> {type} </p>
-            </div>
+            <PokeCard id={id} name={name} image={image} type={type} />
         </div>
     )
 }


### PR DESCRIPTION
## What are you trying to do?
Create card component and display in a grid

## Why is this change needed?
To display each pokemon in individual card components.

## How did you resolve the issue?
Add card and card grid styling to CSS. Grid with 3 columns made using `grid-template-columns: repeat(3, minmax(230px, 1fr));`.

### Checklist
- [x] I have 🎩'd this locally.
- [x] I have provided instructions on how to run the app.