### PR TITLE
Get official artwork for fetched pokemon

### DIFF
--- a/src/Pokemon.tsx
+++ b/src/Pokemon.tsx
@@ -53,7 +53,7 @@ function Pokemon() {
     return (
         <div className="test">
             <p>{id} | {name} | {type}</p>
-            {/* <img src={image} /> */}
+            <img src={image} />
         </div>
     )
 }


### PR DESCRIPTION
## What are you trying to do?
Display image based on fetched pokemon

## Why is this change needed?
There is no image currently displayed, only text

## How did you resolve the issue?
PokeAPI returns a link to the image via `pokemon.sprites.other['official-artwork'].front_default` which can then be fed to an `img` component by `src={image}`.

### Checklist
- [x] I have 🎩'd this locally.
- [x] I have provided instructions on how to run the app.