### PR TITLE
Display multiple pokemon in grid

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -37,7 +37,7 @@
   }
 }
 
-.cards {
+.card-grid {
   place-self: center;
   display: grid;
   /* eventually move <Pokemon/> component in App.tsx out of header section
@@ -46,8 +46,10 @@
      window size changes */
   /* grid-template-columns: repeat(auto-fill, 200px); */
   /* grid-template-columns: repeat(auto-fill, minmax(230px, 1fr)); */
+  /* grid-template-columns: repeat(auto-fit, minmax(0, min(100%/3, max(64px, 100%/5)))); */
   grid-template-columns: repeat(3, minmax(230px, 1fr));
-  grid-gap: 20px;
+  grid-gap: 70px 30px;
+  margin: 100px;
 }
 
 .card {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,38 +3,38 @@ import logo from './logo.svg';
 import './App.css';
 import Pokemon from './Pokemon';
 
-interface IPokemon {
-  id: number;
-  name: string;
-  image: string;
-  type: string;
-}
+// interface IPokemon {
+//   id: number;
+//   name: string;
+//   image: string;
+//   type: string;
+// }
 
 function App() {
 
-  const getPokemon = async (id: number): Promise<IPokemon> => {
-    const data: Response = await fetch(`https://pokeapi.co/api/v2/pokemon/${id}`)
-    const pokemon: any = await data.json()
-    const pokemonType: string = pokemon.types
-        .map((poke: any) => poke.type.name)
-        .join(", ")
-    const pokemonAbilities: string = pokemon.abilities
-        .map((poke: any) => poke.ability.name)
-        .join(", ")
-    console.log(pokemonAbilities)
-    // setName(pokemon.name)
-    const transformedPokemon = {
-        id: pokemon.id,
-        name: pokemon.name,
-        // image: `${pokemon.sprites.front_default}`,
-        image: `${pokemon.sprites.other['official-artwork'].front_default}`,
-        type: pokemonType,
-    }
+//   const getPokemon = async (id: number): Promise<IPokemon> => {
+//     const data: Response = await fetch(`https://pokeapi.co/api/v2/pokemon/${id}`)
+//     const pokemon: any = await data.json()
+//     const pokemonType: string = pokemon.types
+//         .map((poke: any) => poke.type.name)
+//         .join(", ")
+//     const pokemonAbilities: string = pokemon.abilities
+//         .map((poke: any) => poke.ability.name)
+//         .join(", ")
+//     console.log(pokemonAbilities)
+//     // setName(pokemon.name)
+//     const transformedPokemon = {
+//         id: pokemon.id,
+//         name: pokemon.name,
+//         // image: `${pokemon.sprites.front_default}`,
+//         image: `${pokemon.sprites.other['official-artwork'].front_default}`,
+//         type: pokemonType,
+//     }
 
-    return transformedPokemon
-}
+//     return transformedPokemon
+// }
 
-  const temp = getPokemon(2);
+//   const temp = getPokemon(2);
 
   return (
     <div className="App">

--- a/src/PokeCard/PokeCard.tsx
+++ b/src/PokeCard/PokeCard.tsx
@@ -4,17 +4,18 @@ interface IPokemon {
     id: number;
     name: string;
     image: string;
-    type: string;
+    firstType: string;
+    secondType: string;
 }
 
-export const PokeCard = ({id, name, image, type}:IPokemon) => {
+export const PokeCard = ({id, name, image, firstType, secondType}:IPokemon) => {
     return (
         <div>
             <div className="card">
             <img src={image} />
             <p className="id">#{id}</p>
             <p className="name">{name}</p>
-            <p className='type'> {type} </p>
+            <p className='type'> {firstType} {secondType} </p>
             </div>
         </div>
     )

--- a/src/Pokemon.tsx
+++ b/src/Pokemon.tsx
@@ -1,61 +1,66 @@
 import React, { useEffect, useState } from 'react';
 import { PokeCard } from './PokeCard';
+import { usePokemons } from './hooks/usePokemons';
 
 interface IPokemon {
     id: number;
     name: string;
     image: string;
-    type: string;
+    firstType: string;
+    secondType: string;
 }
 
 // function Pokemon({id, name, image, type}:IPokemon) {
 function Pokemon() {
-    const [name, setName] = useState<any>('' || []);
-    const [type, setType] = useState('');
-    const [image, setImage] = useState('');
-    const [id, setId] = useState(0);
+    // const [name, setName] = useState<any>('' || []);
+    // const [type, setType] = useState('');
+    // const [image, setImage] = useState('');
+    // const [id, setId] = useState(0);
 
-    useEffect(() => {
-        getPokemon(1)
-    })
+    // useEffect(() => {
+    //     getPokemon(1)
+    // })
 
-    const getPokemon = async (id: number): Promise<void> => {
-        const data: Response = await fetch(`https://pokeapi.co/api/v2/pokemon/${id}`)
-        const pokemon: any = await data.json()
-        const pokemonType: string = pokemon.types
-            .map((poke: any) => poke.type.name)
-            .join(", ")
-        const pokemonAbilities: string = pokemon.abilities
-            .map((poke: any) => poke.ability.name)
-            .join(", ")
-        console.log(pokemonAbilities)
+    // const getPokemon = async (id: number): Promise<void> => {
+    //     const data: Response = await fetch(`https://pokeapi.co/api/v2/pokemon/${id}`)
+    //     const pokemon: any = await data.json()
+    //     const pokemonType: string = pokemon.types
+    //         .map((poke: any) => poke.type.name)
+    //         .join(", ")
+    //     const pokemonAbilities: string = pokemon.abilities
+    //         .map((poke: any) => poke.ability.name)
+    //         .join(", ")
+    //     console.log(pokemonAbilities)
 
-        const transformedPokemon = {
-            id: pokemon.id,
-            name: pokemon.name,
-            image: `${pokemon.sprites.other['official-artwork'].front_default}`,
-            type: pokemonType,
-        }
+    //     const transformedPokemon = {
+    //         id: pokemon.id,
+    //         name: pokemon.name,
+    //         image: `${pokemon.sprites.other['official-artwork'].front_default}`,
+    //         firstType: pokemonType,
+    //         secondType: pokemonType,
+    //     }
 
-        setId(transformedPokemon.id);
-        setName(transformedPokemon.name);
-        setType(transformedPokemon.type);
-        setImage(transformedPokemon.image);
-        const res = showPokemon(transformedPokemon)
-        console.log(res)
-    }
+    //     setId(transformedPokemon.id);
+    //     setName(transformedPokemon.name);
+    //     setType(transformedPokemon.firstType);
+    //     setImage(transformedPokemon.image);
+    //     const res = showPokemon(transformedPokemon)
+    //     console.log(res)
+    // }
 
-    const showPokemon = (pokemon: IPokemon): string => {
-        let output: string = `${pokemon.id} ${pokemon.name} ${pokemon.type} ${pokemon.image}`
-        return output
-    }
+    // const showPokemon = (pokemon: IPokemon): string => {
+    //     let output: string = `${pokemon.id} ${pokemon.name} ${pokemon.firstType} ${pokemon.image}`
+    //     return output
+    // }
 
     // getPokemon(736);
     // const typeColour = "#FF5733";
     const typeColour = "white";
+    const { pokemons } = usePokemons();
+
     return (
-        <div className="cards">
-            <PokeCard id={id} name={name} image={image} type={type} />
+        <div className="card-grid">
+            {pokemons.map((pokemon: any) => <PokeCard id={pokemon.id} name={pokemon.name} image={pokemon.image} firstType={pokemon.firstType} secondType={pokemon.secondType} />)}
         </div>
     )
 }

--- a/src/helpers/fetchAllPokemon.tsx
+++ b/src/helpers/fetchAllPokemon.tsx
@@ -1,0 +1,22 @@
+import { fetchPokemon } from "./fetchPokemon"
+
+export const fetchAllPokemon = async () => {
+    const limit = 100 // up to 898
+    const url = `https://pokeapi.co/api/v2/pokemon?limit=${limit}`;
+    const result = await fetch(url);
+    const { results } = await result.json();
+    const promises = results.map(async (pokemon: any) => fetchPokemon(pokemon.url));
+    const pokemonData = await Promise.all(promises);
+    return transformedPokemonData(pokemonData);
+};
+
+const transformedPokemonData = (data: any) => {
+    const pokemons = data.map(({ id, name, sprites, types }: any) => {
+        name = name.slice(0,1).toUpperCase() + name.slice(1);
+        const image = sprites.other['official-artwork'].front_default;
+        const firstType = types[0].type.name;
+        const secondType = types[1]?.type.name;
+        return { id, name, image, firstType, secondType };
+    });
+    return pokemons;
+};

--- a/src/helpers/fetchPokemon.tsx
+++ b/src/helpers/fetchPokemon.tsx
@@ -1,0 +1,6 @@
+export const fetchPokemon = async (url: string) => {
+    const result = await fetch(url);
+    const data = await result.json();
+    console.log({data});
+    return data;
+}

--- a/src/hooks/usePokemons.tsx
+++ b/src/hooks/usePokemons.tsx
@@ -1,0 +1,19 @@
+import { useState, useEffect } from 'react';
+import { fetchAllPokemon } from '../helpers/fetchAllPokemon';
+
+export const usePokemons = () => {
+  const [isLoading, setIsLoading] = useState(true);
+  const [pokemons, setPokemons] = useState<any>([]);
+
+  useEffect(() => {
+    fetchAllPokemon().then((pokemons) => {
+      setIsLoading(false);
+      setPokemons(pokemons);
+    });
+  }, []);
+
+  return {
+    isLoading,
+    pokemons,
+  };
+};


### PR DESCRIPTION
## What are you trying to do?
Fetch multiple pokemon from the PokeAPI and display each in a PokeCard on a grid.

## Why is this change needed?
Currently can only display information of one pokemon at a time.

## How did you resolve the issue?
Fetch all pokemon and store in state, then map each to a PokeCard and display in a grid using `grid-template-columns: repeat(3, minmax(230px, 1fr))`.

### Checklist
- [x] I have 🎩'd this locally.
- [x] I have provided instructions on how to run the app.