### PR TITLE
Display multiple pokemon in grid component

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -22,6 +22,7 @@
   justify-content: normal;
   font-size: calc(10px + 2vmin);
   color: white;
+  height: 100%;
 }
 
 .App-link {
@@ -35,22 +36,6 @@
   to {
     transform: rotate(360deg);
   }
-}
-
-.card-grid {
-  place-self: center;
-  display: grid;
-  /* eventually move <Pokemon/> component in App.tsx out of header section
-     and then need to allow one of the following lines. First keeps width
-     fixed upon window resizing, while second changes width to fill when
-     window size changes */
-  /* grid-template-columns: repeat(auto-fill, 200px); */
-  /* grid-template-columns: repeat(auto-fill, minmax(230px, 1fr)); */
-  /* grid-template-columns: repeat(auto-fit, minmax(0, min(100%/3, max(64px, 100%/5)))); */
-  grid-template-columns: repeat(3, minmax(230px, 1fr));
-  grid-gap: 70px 30px;
-  margin-top: 200px;
-  margin-bottom: 100px;
 }
 
 .card {

--- a/src/Pokemon.tsx
+++ b/src/Pokemon.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { PokeCard } from './components/PokeCard';
+import { PokeGrid } from './components/PokeGrid';
 import { Searchbar } from './components/Searchbar';
 import { usePokemons } from './hooks/usePokemons';
 
@@ -12,11 +12,7 @@ interface Pokemon {
 }
 
 const Pokemon = () => {
-
-
-    // getPokemon(736);
-    // const typeColour = "#FF5733";
-    const typeColour = "white";
+    // const typeColour = "white";
     const { pokemons } = usePokemons();
     const [search, setSearch] = useState('');
 
@@ -29,7 +25,6 @@ const Pokemon = () => {
 
         const filtered = pokemons.filter(
             (pokemon: Pokemon) => pokemon.name.includes(search.toLowerCase()) || (pokemon.id.toString() === search )
-            // (pokemon: Pokemon) => pokemon.name.includes(search.toLowerCase()) || pokemon.id.toString().includes(search)
         );
 
         console.log({filtered});
@@ -39,9 +34,7 @@ const Pokemon = () => {
     return (
         <div>
             <Searchbar search={search} setSearch={setSearch}/>
-            <div className="card-grid">
-                {filteredPokemon().map((pokemon: Pokemon) => <PokeCard key={pokemon.id} {...pokemon} />)}
-            </div>
+            <PokeGrid pokemons={filteredPokemon()} />
         </div>
     )
 }

--- a/src/components/PokeGrid/PokeGrid.css
+++ b/src/components/PokeGrid/PokeGrid.css
@@ -1,0 +1,27 @@
+.card-grid {
+    /* place-self: center; */
+    display: grid;
+    /* eventually move <Pokemon/> component in App.tsx out of header section
+        and then need to allow one of the following lines. First keeps width
+        fixed upon window resizing, while second changes width to fill when
+        window size changes */
+    /* grid-template-columns: repeat(auto-fill, 200px); */
+    /* grid-template-columns: repeat(auto-fill, minmax(230px, 1fr)); */
+    /* grid-template-columns: repeat(auto-fit, minmax(0, min(100%/3, max(64px, 100%/5)))); */
+    grid-template-columns: repeat(3, minmax(230px, 1fr));
+    grid-gap: 70px 30px;
+    margin-top: 175px;
+    margin-bottom: 100px;
+}
+
+.not-found {
+    /* background-color: #F6F8FC; */
+    /* min-height: 100vh; */
+    display: flex;
+    flex-direction: column;
+    /* align-items: center; */
+    /* justify-content: center; */
+    font-size: calc(10px + 2vmin);
+    color: black;
+    margin: 150px auto;
+}

--- a/src/components/PokeGrid/PokeGrid.tsx
+++ b/src/components/PokeGrid/PokeGrid.tsx
@@ -1,0 +1,26 @@
+import { PokeCard } from '../PokeCard';
+
+import './PokeGrid.css';
+
+interface Pokemon {
+    id: number;
+    name: string;
+    image: string;
+    firstType: string;
+    secondType: string;
+}
+
+export const PokeGrid = ({ pokemons }: any) => {
+
+  return (
+    <div>
+        {pokemons.length > 0 ? (
+            <div className="card-grid">
+                {pokemons.map((pokemon: Pokemon) => <PokeCard key={pokemon.id} {...pokemon} />)}
+            </div>
+            ) : (
+            <div className="not-found">- Oh sorry we didn't find that pokemon 🙁 -</div>
+        )}
+    </div>
+  );
+};

--- a/src/components/PokeGrid/index.ts
+++ b/src/components/PokeGrid/index.ts
@@ -1,0 +1,1 @@
+export {PokeGrid} from './PokeGrid';

--- a/src/components/Searchbar/Searchbar.css
+++ b/src/components/Searchbar/Searchbar.css
@@ -28,12 +28,11 @@
 }
 
 input {
-    padding-left: 5vw;
+    padding-left: 4vw;
 }
 
 .searchbar input:focus {
     outline: none;
-    /* background-color: #e2e2e2; */
     box-shadow: 0px 5px 20px 1px rgba(0, 0, 0, 0.2);
 }
 


### PR DESCRIPTION
## What are you trying to do?
Separate card-grid code into its own component.

## Why is this change needed?
Currently some styling is in the shared app.

## How did you resolve the issue?
Created and populated new files for PokeGrid component.

### Checklist
- [x] I have 🎩'd this locally.
- [x] I have provided instructions on how to run the app.