### PR TITLE
Pad pokemon IDs to display three digits

### DIFF
--- a/src/components/PokeCard/PokeCard.tsx
+++ b/src/components/PokeCard/PokeCard.tsx
@@ -2,7 +2,7 @@ import React, {useState} from 'react';
 // import './PokeCard.css'
 
 interface Pokemon {
-    id: number;
+    id: number | string;
     name: string;
     image: string;
     firstType: string;
@@ -14,11 +14,22 @@ export const PokeCard = ({id, name, image, firstType, secondType}: Pokemon) => {
         return name.slice(0,1).toUpperCase() + name.slice(1)
     }
 
+    const padId = () => {
+        const idLength = id.toString().length;
+        if (idLength === 1) {
+            id = "00" + id.toString();
+        }
+        else if (idLength === 2) {
+            id = "0" + id.toString();
+        }
+        return id;
+    }
+
     return (
         <div>
             <div className="card">
             <img src={image} />
-            <p className="id">#{id}</p>
+            <p className="id">#{padId()}</p>
             <p className="name">{capitalizedName()}</p>
             <p className='type'> {firstType} {secondType} </p>
             </div>


### PR DESCRIPTION
## What are you trying to do?
Pad Pokemon IDs so that they are in 000 format.

## Why is this change needed?
Uniform display of Pokemon IDs

## How did you resolve the issue
Added a function in PokeCard component to check the length of the ID and pad appropriately with zeroes when length is less than three.

### Checklist
- [x] I have 🎩'd this locally.
- [x] I have provided instructions on how to run the app.