### PR TITLE
Separate pokecard css and fix iOS bug

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -38,56 +38,6 @@
   }
 }
 
-.card {
-  width: 319px;
-  height: 192px;
-  background-color: #FFFFFF;
-  box-shadow: 0px 5px 20px 1px rgba(0, 0, 0, 0.1);
-  padding: 8px;
-  border-radius: 20px;
-  font-size: 24px;
-  margin: auto;
-}
-
-.card img {
-  /* object-fit: cover; */
-  width: 50%;
-  /* height: 70%; */
-  margin: auto;
-  position: relative;
-  top: -40%;
-}
-
-.id {
-  position: relative;
-  top: -45%;
-  margin-bottom: 0px;
-  color: #8F9396;
-  font-weight: bold;
-  font-size: 16px;
-}
-
-.name {
-  position: relative;
-  top: -45%;
-  margin-top: 0px;
-  margin-bottom: 0px;
-  color: #000000;
-  font-weight: bold;
-}
-
-.type {
-  margin: auto;
-  position: relative;
-  top: -45%;
-  margin-top: 0px;
-  margin-bottom: 0px;
-  /* width: 60px; */
-  padding: 2px;
-  color: #000000;
-  font-size: 16px;
-}
-
 .container {
   background-color: white;
   color: black;

--- a/src/components/PokeCard/PokeCard.css
+++ b/src/components/PokeCard/PokeCard.css
@@ -13,6 +13,7 @@
   width: 50%;
   margin: auto;
   position: relative;
+  display: block;
   top: -40%;
 }
 

--- a/src/components/PokeCard/PokeCard.css
+++ b/src/components/PokeCard/PokeCard.css
@@ -1,0 +1,46 @@
+.card {
+  width: 319px;
+  height: 192px;
+  background-color: #FFFFFF;
+  box-shadow: 0px 5px 20px 1px rgba(0, 0, 0, 0.1);
+  padding: 8px;
+  border-radius: 20px;
+  font-size: 24px;
+  margin: auto;
+}
+
+.card img {
+  width: 50%;
+  margin: auto;
+  position: relative;
+  top: -40%;
+}
+
+.id {
+  position: relative;
+  top: -45%;
+  margin-bottom: 0px;
+  color: #8F9396;
+  font-weight: bold;
+  font-size: 16px;
+}
+
+.name {
+  position: relative;
+  top: -45%;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  color: #000000;
+  font-weight: bold;
+}
+
+.type {
+  margin: auto;
+  position: relative;
+  top: -45%;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  padding: 2px;
+  color: #000000;
+  font-size: 16px;
+}

--- a/src/components/PokeCard/PokeCard.tsx
+++ b/src/components/PokeCard/PokeCard.tsx
@@ -1,5 +1,5 @@
 import React, {useState} from 'react';
-// import './PokeCard.css'
+import './PokeCard.css'
 
 interface Pokemon {
     id: number | string;


### PR DESCRIPTION
## What are you trying to do?
Move the css for `<PokeCard />` to a separate file. Also fix a bug in Safari and iOS where the pokemon image isn't positioned properly.

## Why is this change needed?
Separate css for better compartmentalization. Fix bug.

## How did you resolve the issue?
Move the css to a new file and fixed bug by adding `display: block` so the image behaves as a block-level element

### Checklist
- [x] I have 🎩'd this locally.
- [x] I have provided instructions on how to run the app.