### PR TITLE
Fetch pokemon stats from api

### DIFF
--- a/src/helpers/fetchAllPokemon.tsx
+++ b/src/helpers/fetchAllPokemon.tsx
@@ -11,11 +11,13 @@ export const fetchAllPokemon = async () => {
 };
 
 const transformedPokemonData = (data: any) => {
-    const pokemons = data.map(({ id, name, sprites, types }: any) => {
+    const pokemons = data.map(({ id, name, sprites, types, stats }: any) => {
         const image = sprites.other['official-artwork'].front_default;
         const firstType = types[0].type.name;
         const secondType = types[1]?.type.name;
-        return { id, name, image, firstType, secondType };
+        const [hp, attack, defense, specialAttack, specialDefense, speed] = stats.map((stat: any) => stat.base_stat);
+        const pokeStats = {hp, attack, defense, specialAttack, specialDefense, speed};
+        return { id, name, image, firstType, secondType, pokeStats };
     });
     return pokemons;
 };


### PR DESCRIPTION
## What are you trying to do?
Fetch pokemon stats (HP, attack, defence, etc.) from PokeAPI.

## Why is this change needed?
These stats are important for the details page.

## How did you resolve the issue?
Update the `fetchAllPokemons()` function that fetches data from the API. The API has a `stats` array with all the stats; these are mapped to get `stat.base_stat` for each hp, attack, etc. and saved in the `pokeStats` array.

### Checklist
- [x] I have 🎩'd this locally.
- [x] I have provided instructions on how to run the app.