### PR TITLE
Implement localStorage caching with fetch()

### DIFF
--- a/src/helpers/fetchAllPokemon.tsx
+++ b/src/helpers/fetchAllPokemon.tsx
@@ -1,13 +1,29 @@
 import { fetchPokemon } from "./fetchPokemon"
 
+const CACHE_KEY = 'allPokemon';
+const CACHE_TTL = 3600 * 100;
+
 export const fetchAllPokemon = async () => {
-    const limit = 100 // up to 898
+    const limit = 151 // up to 898
     const url = `https://pokeapi.co/api/v2/pokemon?limit=${limit}`;
+
+    const cachedData = localStorage.getItem(CACHE_KEY);
+    if (cachedData) {
+        const cachedResult = JSON.parse(cachedData);
+        const now = new Date().getTime();
+        if (cachedResult.expiry > now) {
+            return cachedResult.data;
+        }
+    }
+
     const result = await fetch(url);
     const { results } = await result.json();
     const promises = results.map(async (pokemon: any) => fetchPokemon(pokemon.url));
     const pokemonData = await Promise.all(promises);
-    return transformedPokemonData(pokemonData);
+    const transformedData =  transformedPokemonData(pokemonData);
+
+    const expiry = new Date().getTime() + CACHE_TTL;
+    localStorage.setItem(CACHE_KEY, JSON.stringify({data: transformedData, expiry}))
 };
 
 const transformedPokemonData = (data: any) => {


### PR DESCRIPTION
Resolves #63 

## What are you trying to do?

Cache fetched pokemon data instead of calling the API every time.

## Why is this change needed?

Refetching pokemon data every time is slow and wasteful. The data doesn't change so we can just cache it instead.

## How did you resolve the issue?

Cache the data using `localStorage`.

### Checklist
- [x] I have tested this locally.
- [x] I have provided instructions on how to run the app.