### PR TITLE
Style details page with image and stats

### DIFF
--- a/src/components/StatRow/StatRow.tsx
+++ b/src/components/StatRow/StatRow.tsx
@@ -1,0 +1,25 @@
+import { Statbar } from "../Statbar/Statbar"
+
+import './StatsRow.css';
+
+export const StatRow = ({name, value}: any) => {
+
+  const statName = statNames[name];
+
+  return (
+    <div className="row-container">
+      <span className="stat-name">{statName}</span>
+      <span className="stat-value">{value}</span>
+      <Statbar value={value} />
+    </div>
+  )
+}
+
+const statNames: any = {
+  hp: 'HP',
+  attack: 'Attack',
+  defense: 'Defense',
+  specialAttack: 'Sp. Attack',
+  specialDefense: 'Sp. Defense',
+  speed: 'Speed',
+}

--- a/src/components/StatRow/StatsRow.css
+++ b/src/components/StatRow/StatsRow.css
@@ -1,0 +1,66 @@
+.row-container {
+  display: grid;
+  grid-template-columns: 150px 60px auto;
+  gap: 25px;
+  align-items: center;
+  margin: 1% 0;
+  font-size: 0.8em;
+  font-weight: 700;
+}
+
+.stat-name {
+  text-align: left;
+  color: rgba(0, 0, 0, 0.25);
+  width: 150px;
+}
+
+.stat-value {
+  text-align: right;
+  color: rgba(0, 0, 0, 0.4);
+  width: 60px;
+}
+
+@media screen and (max-width: 720px) {
+  .row-container {
+    grid-template-columns: 90px 30px auto;
+    gap: 10px;
+  }
+
+  .stat-name {
+    width: 90px;
+  }
+  
+  .stat-value {
+    width: 30px;
+  }
+}
+
+@media screen and (max-width: 1150px) and (min-width: 721px) {
+  .row-container {
+    grid-template-columns: 140px 45px auto;
+    gap: 15px;
+  }
+
+  .stat-name {
+    width: 140px;
+  }
+  
+  .stat-value {
+    width: 45px;
+  }
+}
+
+@media screen and (max-width: 1400px) and (min-width: 1151px) {
+  .row-container {
+    grid-template-columns: 135px 35px auto;
+    gap: 10px;
+  }
+
+  .stat-name {
+    width: 135px;
+  }
+  
+  .stat-value {
+    width: 35px;
+  }
+}

--- a/src/components/Statbar/Statbar.css
+++ b/src/components/Statbar/Statbar.css
@@ -1,0 +1,26 @@
+.container {
+  width: 350px;
+  height: 6px;
+  background-color: rgba(0, 0, 0, 0.1);
+  border-radius: 5px;
+  overflow: hidden;
+  padding: 0;
+}
+
+@media screen and (max-width: 720px) {
+  .container {
+    width: 170px;
+  }
+}
+
+@media screen and (max-width: 1151px) and (min-width: 721px) {
+  .container {
+    width: 350px;
+  }
+}
+
+@media screen and (max-width: 1400px) and (min-width: 1151px) {
+  .container {
+    width: 290px;
+  }
+}

--- a/src/components/Statbar/Statbar.tsx
+++ b/src/components/Statbar/Statbar.tsx
@@ -1,0 +1,20 @@
+import './Statbar.css';
+
+export const Statbar = ({value}: any) => {
+  // max value for each stat is 255
+  const percent = (value / 255) * 100;
+
+  const fillerStyles = {
+    height: '100%',
+    width: `${percent}%`,
+    backgroundColor: 'rgba(0, 0, 0, 0.3)',
+    borderRadius: 'inherit',
+    transition: 'width 0.3s ease-in-out',
+  }
+
+  return (
+    <div className="container">
+      <div style={fillerStyles} />
+    </div>
+  )
+}

--- a/src/pages/DetailsPage.css
+++ b/src/pages/DetailsPage.css
@@ -1,0 +1,65 @@
+.details-container {
+  width: 100%;
+  height: 100vh;
+  align-content: center;
+}
+
+.content {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  /* grid-template-columns: repeat(auto-fill, minmax(700px, 1fr)); */
+  margin: 0 5%;
+  align-items: center;
+  justify-content: end;
+}
+
+.header {
+  text-align: left;
+  font-weight: 600;
+}
+
+.stats-table {
+  justify-self: end;
+}
+
+.japanese-name {
+  position: absolute;
+  font-size: 4.5em;
+  font-weight: 700;
+  color: rgba(0,0,0,0.4);
+  text-align: left;
+}
+
+img {
+  width: 85%;
+}
+
+@media screen and (max-width: 720px) {
+  .details-container {
+    align-content: normal;
+  }
+
+  .header {
+    margin-top: 20%;
+  }
+
+  .japanese-name {
+    font-size: 3em;
+    font-weight: 900;
+  }
+}
+
+@media screen and (max-width: 1150px) {
+  .content {
+    grid-template-columns: 1fr;
+  }
+
+  .stats-table {
+    justify-self: center;
+  }
+
+  img {
+    width: 70%;
+  }
+}
+

--- a/src/pages/DetailsPage.tsx
+++ b/src/pages/DetailsPage.tsx
@@ -1,5 +1,7 @@
-import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
+import { StatRow } from '../components/StatRow/StatRow';
+
+import './DetailsPage.css';
 
 export const DetailsPage = () => {
   const state = useLocation().state;
@@ -18,18 +20,58 @@ export const DetailsPage = () => {
       id = state.id.toString();
     }
     return id;
-}
+  }
+
+  document.body.style.backgroundColor = typecolors[state.firstType];
 
   return (
-    <div style={{textDecoration: 'none', color: 'black'}}>
-      <p>{capitalizedName} #{padId()}</p>
-      <p>HP: {state.pokeStats.hp}</p>
-      <p>Attack: {state.pokeStats.attack}</p>
-      <p>Defense: {state.pokeStats.defense}</p>
-      <p>Sp Attack: {state.pokeStats.specialAttack}</p>
-      <p>Sp Defense: {state.pokeStats.specialDefense}</p>
-      <p>Speed: {state.pokeStats.speed}</p>
+    <div className='details-container' style={{backgroundColor: typecolors[state.firstType]}}>
+      <div style={{margin: "50px 5%"}}>
+        <div className='header'>
+          <p style={{fontSize: '2rem', margin: '0'}}>#{padId()}</p>
+          <p style={{fontSize: '3.5rem', margin: '0'}}>{capitalizedName}</p>
+        </div>
+
+        <div className='content'>
+          <div style={{textAlign: 'right'}}>
+            <div className='japanese-name'>フシギダネ</div>
+            <img src={state.image} alt={capitalizedName} />
+          </div>
+          
+          <div className='stats-table'>
+            {Object.entries(state.pokeStats).map(([key, value]) => (
+              <StatRow name={key} value={value} key={key} />
+            ))}
+          </div>
+        </div>
+      </div>
+
       <Link to={{pathname: '/'}} style={{textDecoration: 'none'}}>Back to search</Link>
     </div>
   )
+}
+
+interface TypeColors {
+  [key: string]: string;
+}
+
+const typecolors: TypeColors = {
+  'fire': '#FEA755',
+  'water': '#58ABF6',
+  'grass': '#96BC8F',
+  'normal': '#B6B9C3',
+  'flying': '#88A2DE',
+  'fighting': '#D95672',
+  'poison': '#987195',
+  'electric': '#ECCB69',
+  'ground': '#E88A5C',
+  'rock': '#D1C299',
+  'psychic': '#ED6F6D',
+  'ice': '#A0D6DD',
+  'bug': '#9CD37F',
+  'ghost': '#8173B9',
+  'steel': '#5C8FAF',
+  'dragon': '#7583B5',
+  'dark': '#6F6E77',
+  'fairy': '#E1ABC2',
 }


### PR DESCRIPTION
Resolves #40 

## What are you trying to do?
Style the details page to display the pokemon id, name, image, and stats.

## Why is this change needed?
To better display details page information.

## How did you resolve the issue?
The details page displays the pokemon's id, name and media image on the left side of the screen. Stats are shown on the right in a series of `StatRow` components. Media queries are used to change this from a two panel layout on large screens to a single column on small screens, along with adjustments to font and image sizes, and spacing.

### Checklist
- [x] I have tested this locally.
- [x] I have provided instructions on how to run the app.