### PR TITLE
Handle page loading before data finishes loading

### DIFF
--- a/src/Pokemon.tsx
+++ b/src/Pokemon.tsx
@@ -14,12 +14,14 @@ interface Pokemon {
 
 const Pokemon = () => {
     // const typeColour = "white";
-    const { pokemons } = usePokemons();
+    const { isLoading, pokemons } = usePokemons();
     const [search, setSearch] = useState('');
 
     const currentPage = 0;
 
     const filteredPokemon = () => {
+        if (!pokemons) return [];
+
         if (search.length === 0) {
             return pokemons.slice(currentPage, currentPage + 50);
         }

--- a/src/hooks/usePokemons.tsx
+++ b/src/hooks/usePokemons.tsx
@@ -4,16 +4,30 @@ import { fetchAllPokemon } from '../helpers/fetchAllPokemon';
 export const usePokemons = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [pokemons, setPokemons] = useState<any>([]);
+  const [error, setError] = useState<Error>();
 
   useEffect(() => {
-    fetchAllPokemon().then((pokemons) => {
-      setIsLoading(false);
-      setPokemons(pokemons);
-    });
-  }, []);
+    const fetchData = async () => {
+      try {
+        setIsLoading(true);
+
+        const fetchedPokemons = await fetchAllPokemon();
+        setPokemons(fetchedPokemons);
+      } catch (err) {
+        setError(new Error('Failed to fetch Pokemon data'));
+        setPokemons([]);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchData();
+
+  }, [isLoading]);
 
   return {
     isLoading,
     pokemons,
+    error,
   };
 };


### PR DESCRIPTION
Resolves #

## What are you trying to do?
Handle the case where the page tries to render before the data has finished loading. This usually happens on the first load and requires a refresh to fix.

## Why is this change needed?
Currently the page tries rendering before the data has finished loading, which throws an error as `pokemon` is null. This only happens on the first load as refreshing the page uses the cached data.

## How did you resolve the issue?
Added a line to handle the case when `pokemon` is null and added `isLoading` to the `useEffect` dependency list to trigger reloading when the data finishes loading.  

### Checklist
- [x] I have tested this locally.
- [x] I have provided instructions on how to run the app.