### PR TITLE
Fix search icon position in searchbar

### DIFF
--- a/src/components/Searchbar/Searchbar.css
+++ b/src/components/Searchbar/Searchbar.css
@@ -39,9 +39,10 @@ input {
 
 .searchbar .search-icon {
     position: absolute;
-    top: 15px;
+    top: 14px;
     left: 25px;
     height: 25px;
+    width: 25px;
 }
 
 @media screen and (max-width: 720px) {


### PR DESCRIPTION
Resolves #71 

## What are you trying to do?
Fixes bug in the placement of the search icon.

## Why is this change needed?
Search icon was rendering towards the centre of the search bar instead of to the left.

## How did you resolve the issue?
Small change in the search icon styling (applying `width`). Also reduced the `top` slightly to better centre it.

### Checklist
- [x] I have tested this locally.
- [x] I have provided instructions on how to run the app.