### PR TITLE
Apply basic pagination on scroll

### DIFF
--- a/src/Pokemon.tsx
+++ b/src/Pokemon.tsx
@@ -20,7 +20,7 @@ const Pokemon = () => {
     const [offset, setOffset] = useState(50);
     const observerTarget = useRef<HTMLDivElement>(null);
 
-    const numberOfPokemon = 1025
+    const numberOfPokemon = 1025;
     const {pokemonData: pokemons, loading, error} = useFetchPokemonQuery(numberOfPokemon);
 
     const currentPage = 0;

--- a/src/Pokemon.tsx
+++ b/src/Pokemon.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { PokeGrid } from './components/PokeGrid';
 import { Searchbar } from './components/Searchbar';
 import { useFetchPokemonQuery } from './hooks/useFetchPokemonQuery';
@@ -17,15 +17,20 @@ interface Pokemon {
 const Pokemon = () => {
     // const typeColour = "white";
     const [search, setSearch] = useState('');
-    const {pokemonData: pokemons, loading, error} = useFetchPokemonQuery();
+    const [offset, setOffset] = useState(50);
+    const observerTarget = useRef<HTMLDivElement>(null);
+
+    const numberOfPokemon = 1025
+    const {pokemonData: pokemons, loading, error} = useFetchPokemonQuery(numberOfPokemon);
 
     const currentPage = 0;
+    const isSearching = search.length > 0;
 
     const filteredPokemon = () => {
         if (!pokemons) return [];
 
-        if (search.length === 0) {
-            return pokemons.slice(currentPage, currentPage + 50);
+        if (!isSearching) {
+            return pokemons.slice(currentPage, offset);
         }
 
         const filtered = pokemons.filter(
@@ -35,10 +40,32 @@ const Pokemon = () => {
         return filtered
     }
 
+    useEffect(() => {
+        const options = {
+            root: null,
+            rootMargin: '20px',
+            threshold: 0.1,
+        };
+
+        const observer = new IntersectionObserver((entries) => {
+            const target = entries[0];
+            if (target.isIntersecting && !loading && !isSearching && offset < numberOfPokemon) {
+                setOffset(prev => prev + 50);
+            }
+        }, options);
+
+        if (observerTarget.current) {
+            observer.observe(observerTarget.current);
+        }
+
+        return () => observer.disconnect();
+    }, [loading, isSearching, offset, numberOfPokemon]);
+
     return (
         <div>
             <Searchbar search={search} setSearch={setSearch}/>
             <PokeGrid pokemons={filteredPokemon()} />
+            <div ref={observerTarget} />
         </div>
     )
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,10 +8,23 @@ import reportWebVitals from './reportWebVitals';
 
 const cache = new InMemoryCache();
 
-await persistCache({
-  cache,
-  storage: new LocalStorageWrapper(window.localStorage),
-});
+function measureCacheSize() {
+  const state = cache.extract();
+  const size = new TextEncoder().encode(JSON.stringify(state)).length;
+  console.log(`Cache size: ${size} bytes (${(size/1024/1024).toFixed(2)} MB)`);
+  return size;
+}
+
+try {
+  await persistCache({
+    cache,
+    storage: new LocalStorageWrapper(window.sessionStorage),
+  });
+  console.log('Caching succeeded')
+  setTimeout(measureCacheSize, 500);
+} catch (e) {
+  console.warn('Caching failed')
+}
 
 const client = new ApolloClient({
   uri: 'https://beta.pokeapi.co/graphql/v1beta',


### PR DESCRIPTION
## What are you trying to do?
Apply basic pagination where only a few pokemon are shown initially and more load when you reach the bottom of the page.

## Why is this change needed?
Pagination is beneficial because while GraphQL fetches everything in a single request, fetching each image from the URL requires an additional request. With 1025 pokemon, this adds up to a lot of requests and takes a while to load and handle, which is unnecessary since that many pokemon can't be viewed at a time anyway. Pagination makes everything more manageable and greatly reduces (or at least spreads out) the number of requests.

## How did you resolve the issue?
Since the PokeApi doesn't appear to have `pageInfo` for cursor-based pagination we're using offset-based pagination. Using `IntersectionObserver` to observe when the `div` at the end of the page has been reached (intersected), we can increment `offset` each time and return all the pokemon from 0 to `offset`.

The target `div` is normally at the bottom of the page, but is usually visible when searching as fewer pokemon are displayed. To prevent offset from incrementing repeatedly, we only increment when `isSearching` is `false`.

### Checklist
- [x] I have tested this locally.
- [x] I have provided instructions on how to run the app.