### PR TITLE
Rename Pokemon page to resolve naming errors

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import "./App.css";
-import Pokemon from "./Pokemon";
+import { PokemonPage } from "./PokemonPage";
 import { DetailsPage } from "./pages/DetailsPage";
 
 function App() {
@@ -9,7 +9,7 @@ function App() {
       <header className="App-header">
         <Router>
           <Routes>
-            <Route path="/" element={<Pokemon />} />
+            <Route path="/" element={<PokemonPage />} />
             <Route path="/details" element={<DetailsPage />} />
           </Routes>
         </Router>

--- a/src/PokemonPage.tsx
+++ b/src/PokemonPage.tsx
@@ -4,7 +4,7 @@ import { Searchbar } from "./components/Searchbar";
 import { useFetchPokemonQuery } from "./hooks/useFetchPokemonQuery";
 import type { Pokemon } from "./hooks/useFetchPokemonQuery";
 
-const Pokemon = () => {
+export const PokemonPage = () => {
   // const typeColour = "white";
   const [search, setSearch] = useState("");
   const [offset, setOffset] = useState(50);
@@ -67,5 +67,3 @@ const Pokemon = () => {
     </div>
   );
 };
-
-export default Pokemon;


### PR DESCRIPTION
## What are you trying to do?
Rename `Pokemon` page to `PokemonPage` for clarity and to resolve an error.

## Why is this change needed?
Resolves an error around exporting Pokemon as default.

## How did you resolve the issue?
Renamed component to `PokemonPage`.

### Checklist
- [x] I have tested this locally.
- [x] I have provided instructions on how to run the app.